### PR TITLE
Fix multi-line no-language code block

### DIFF
--- a/testdata/code_blocks.jira
+++ b/testdata/code_blocks.jira
@@ -19,3 +19,9 @@ def main(self):
 		print "tabbed"
 {code}
 
+Multiple lines, no language annotation:
+
+{code}
+first line
+second line
+{code}

--- a/testdata/code_blocks.md
+++ b/testdata/code_blocks.md
@@ -14,8 +14,14 @@ func main(){}
 
 One more:
 
-```python
+```python 	
 def main(self):
 		print "tabbed"
 ```
 
+Multiple lines, no language annotation:
+
+```
+first line
+second line
+```


### PR DESCRIPTION
Prior to the code changes, the updated test case caused the following failure for `go test`:

```
--- FAIL: TestMDToJira (0.00s)
    --- FAIL: TestMDToJira/code_blocks (0.00s)
        m2j_test.go:31: 
                Error Trace:    m2j_test.go:31
                Error:          Not equal: 
...<snip>...
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -23,4 +23,3 @@
                                 
                                -{code}
                                -first line
                                +{code:first line}
                                 second line
                Test:           TestMDToJira/code_blocks
                Messages:       mismatched output for "code_blocks"
FAIL
exit status 1
FAIL    github.com/kalafut/m2j  1.479s
```

When no language was set, the `(?s)` (allow dot to match newline) meant the first group `(.+?\n)?` was capturing the whole of the first line of the body, instead of leaving it to be captured by the second group.

- Pulls in a fix from the comments for https://gist.github.com/elliotchance/d419395aa776d632d897
- Tweaks the code block regex