### PR TITLE
Invoke pandoc via docker

### DIFF
--- a/m2j.go
+++ b/m2j.go
@@ -1,132 +1,21 @@
 package m2j
 
 import (
-	"fmt"
-	"regexp"
+	"bytes"
+	"os/exec"
 	"strings"
 )
 
-type jiration struct {
-	re   *regexp.Regexp
-	repl interface{}
-}
-
 // MDToJira takes a string in Github Markdown, and outputs Jira text styling
-func MDToJira(str string) string {
-	// normalize any CR-LF into LF
-	lineEndingRE := regexp.MustCompile(`\r?\n`)
-	str = lineEndingRE.ReplaceAllString(str, "\n")
-
-	jirations := []jiration{
-		{ // bold and italics
-			re: regexp.MustCompile(`([*_]{1,2})(\S.*?)([*_]{1,2})`),
-			repl: func(groups []string) string {
-				match, start, content, end := groups[0], groups[1], groups[2], groups[3]
-
-				switch {
-				// Without backreferences in RE2, this is the best we can do
-				case start != end:
-					return match
-				case len(start) == 1:
-					return fmt.Sprintf("_%s_", content)
-				default:
-					return fmt.Sprintf("*%s*", content)
-				}
-			},
-		},
-		{ // code blocks
-			//re: regexp.MustCompile("(?s)```(.+\n)?((?:.|\n)*?)```"),
-			re: regexp.MustCompile("(?s)```([\\w\t ]*)\n(.*?)```"),
-			repl: func(groups []string) string {
-				language := groups[1]
-				body := groups[2]
-				if language == "" {
-					return "{code}\n" + body + "{code}"
-				} else {
-					return fmt.Sprintf("{code:%s}\n%s{code}", strings.TrimSpace(language), body)
-				}
-			},
-		},
-		{ // monospace
-			re:   regexp.MustCompile("`([^`]+)`"),
-			repl: "{{$1}}",
-		},
-		{ // headings
-			re: regexp.MustCompile(`(?m)^(#{1,6})\s`),
-			repl: func(groups []string) string {
-				return fmt.Sprintf("h%d. ", len(groups[1]))
-			},
-		},
-		{ // unnamed links
-			re:   regexp.MustCompile(`<([^>]+?)>`),
-			repl: "[$1]",
-		},
-		{ // named links
-			re:   regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`),
-			repl: "[$1|$2]",
-		},
-		{ // unordered lists
-			re: regexp.MustCompile(`(?m)^([ \t]*)\*\s+`),
-			repl: func(groups []string) string {
-				indent := 0
-				indentStr := groups[1]
-				if indentStr != "" {
-					if string(indentStr[0]) == " " {
-						indent = len(indentStr) / 2
-					} else {
-						indent = len(indentStr)
-					}
-				}
-				return strings.Repeat("*", indent+1) + " "
-			},
-		},
-		{ // ordered lists
-			re: regexp.MustCompile(`(?m)^([ \t]*)\d+[.)]\s+`),
-			repl: func(groups []string) string {
-				indent := 0
-				indentStr := groups[1]
-				if indentStr != "" {
-					if string(indentStr[0]) == " " {
-						indent = len(indentStr) / 2
-					} else {
-						indent = len(indentStr)
-					}
-				}
-				return strings.Repeat("#", indent+1) + " "
-			},
-		},
-	}
-	for _, jiration := range jirations {
-		switch v := jiration.repl.(type) {
-		case string:
-			str = jiration.re.ReplaceAllString(str, v)
-		case func([]string) string:
-			str = replaceAllStringSubmatchFunc(jiration.re, str, v)
-		default:
-			fmt.Printf("I don't know about type %T!\n", v)
-		}
-	}
-	return str
-}
-
-// https://gist.github.com/elliotchance/d419395aa776d632d897
-func replaceAllStringSubmatchFunc(re *regexp.Regexp, str string, repl func([]string) string) string {
-	result := ""
-	lastIndex := 0
-
-	for _, v := range re.FindAllSubmatchIndex([]byte(str), -1) {
-		groups := []string{}
-		for i := 0; i < len(v); i += 2 {
-			if v[i] == -1 || v[i+1] == -1 {
-				groups = append(groups, "")
-			} else {
-				groups = append(groups, str[v[i]:v[i+1]])
-			}
-		}
-
-		result += str[lastIndex:v[0]] + repl(groups)
-		lastIndex = v[1]
+func MDToJira(str string) (string, error) {
+	cmd := exec.Command("docker", "run", "--interactive", "--rm", "pandoc/core:2.11.0.4", "--from=gfm", "--to=jira")
+	cmd.Stdin = strings.NewReader(str)
+	out := bytes.Buffer{}
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
 	}
 
-	return result + str[lastIndex:]
+	return out.String(), nil
 }

--- a/m2j_test.go
+++ b/m2j_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMDToJira(t *testing.T) {
@@ -16,6 +17,7 @@ func TestMDToJira(t *testing.T) {
 		"links",
 		"lists",
 		"crlf",
+		"comments",
 	}
 
 	for _, test := range tests {
@@ -28,7 +30,8 @@ func TestMDToJira(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			output := MDToJira(string(input))
+			output, err := MDToJira(string(input))
+			require.NoError(t, err)
 			assert.Equal(t, string(expected), output, "mismatched output for %q", test)
 		})
 	}

--- a/testdata/code_blocks.jira
+++ b/testdata/code_blocks.jira
@@ -2,26 +2,23 @@ Code blocks
 
 {{Try to confuse things with monospace.}}
 
-{code}
+{code:java}
 func main(){}
 {code}
-
-Another code block (since >1 used to break)
+Another code block \(since >1 used to break)
 
 {code:go}
 func main(){}
 {code}
-
 One more:
 
 {code:python}
 def main(self):
-		print "tabbed"
+        print "tabbed"
 {code}
-
 Multiple lines, no language annotation:
 
-{code}
+{code:java}
 first line
 second line
 {code}

--- a/testdata/code_blocks.md
+++ b/testdata/code_blocks.md
@@ -2,7 +2,7 @@ Code blocks
 
 `Try to confuse things with monospace.`
 
-```
+```  
 func main(){}
 ```
 

--- a/testdata/comments.jira
+++ b/testdata/comments.jira
@@ -1,0 +1,2 @@
+h1. {anchor:a-heading}A heading
+And some text

--- a/testdata/comments.md
+++ b/testdata/comments.md
@@ -1,0 +1,17 @@
+<!--Everything
+in this is a comment
+
+
+that shouldn't `show` up in the Jira
+
+```
+formatted
+```
+
+_text_. No processing of markdown required-->
+
+# A heading
+
+<!-- and another single-line comment -->
+
+And some text

--- a/testdata/crlf.jira
+++ b/testdata/crlf.jira
@@ -1,5 +1,5 @@
 This file uses CRLF line endings.
 
-{code}
+{code:java}
 Some code
 {code}

--- a/testdata/headings.jira
+++ b/testdata/headings.jira
@@ -1,19 +1,12 @@
 Hello
 
-h1. My H1
-
-h2. My H2
-
-h3. My H3
-
-h4. My H4
-
-h5. My H5
-
-h6. My H6
-
+h1. {anchor:my-h1}My H1
+h2. {anchor:my-h2}My H2
+h3. {anchor:my-h3}My H3
+h4. {anchor:my-h4}My H4
+h5. {anchor:my-h5}My H5
+h6. {anchor:my-h6}My H6
 ####### There is no H7
 
- # Ignored
-
+h1. {anchor:not-ignored}Not ignored
 end

--- a/testdata/headings.md
+++ b/testdata/headings.md
@@ -14,6 +14,6 @@ Hello
 
 ####### There is no H7
 
- # Ignored
+ # Not ignored
 
 end

--- a/testdata/links.jira
+++ b/testdata/links.jira
@@ -1,10 +1,8 @@
-h1. Links
-
-This is a plain link which should be left as is (I think)? https://github.com
+h1. {anchor:links}Links
+This is a plain link which should be left as is \(I think)? [https://github.com]
 
 Here is an autolink: [https://github.com]
 
 And here's a named link: [Some text|https://example.com]
 
 Reference links aren't supported yet.
-

--- a/testdata/lists.jira
+++ b/testdata/lists.jira
@@ -1,9 +1,6 @@
-h1. Lists
-
-h2. Unordered
-
-h3. Tab indented
-
+h1. {anchor:lists}Lists
+h2. {anchor:unordered}Unordered
+h3. {anchor:tab-indented}Tab indented
 * Top Level
 * Line 2
 ** Indented
@@ -11,8 +8,7 @@ h3. Tab indented
 *** More indented
 * Back to top level
 
-h3. Space indented
-
+h3. {anchor:space-indented}Space indented
 * Top Level
 * Line 2
 ** Indented
@@ -22,8 +18,7 @@ h3. Space indented
 
 And some text after.
 
-h2. Ordered
-
+h2. {anchor:ordered}Ordered
 # First
 # Second
 # Third multiple words

--- a/testdata/lists.md
+++ b/testdata/lists.md
@@ -26,5 +26,5 @@ And some text after.
 
 1. First
 1. Second
-1) Third multiple words
-  1. Indented
+1. Third multiple words
+    1. Indented

--- a/testdata/text_styles.jira
+++ b/testdata/text_styles.jira
@@ -1,8 +1,7 @@
-This is _italics_!
+This is _italics_\!
 
-This is also _italics_!
+This is also _italics_\!
 
-This is *bold*!
+This is *bold*\!
 
-This is {{mono}}!
-
+This is {{mono}}\!


### PR DESCRIPTION
This is very much a "WDYT" PR. After realising how difficult it was to avoid vulnerabilities processing untrusted input in bash, I decided we were maybe better off in Golang instead. Although it's not the prettiest, converting this library to use `pandoc` via `docker` seems like the best relatively pragmatic way to consistently format across the two tools.

Initially I tried using the Docker SDK to create, attach to and start the pandoc container, but it was turning out vastly more complicated and I didn't see much benefit from it, so this PR simply forks a command instead.

There are a couple of small updates to the markdown test cases that in my testing were consistent with how GitHub handles the markdown. There are also some slightly more impactful, but I think entirely valid/acceptable updates to the expected Jira markdown too.

Lastly, I also added a test case for GitHub markdown comments.